### PR TITLE
adding https support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,30 @@ you need to `login` again on a periodic basis:
 await clientStub.login();
 ```
 
+### Create https connection
+
+If your cluster is using tls/mtls you can pass a node `https.Agent` configured with you
+certificates as follows:
+
+```js
+const https = require('https');
+const fs = require('fs');
+// read your certificates
+const cert = fs.readFileSync('./certs/client.crt', 'utf8');
+const ca = fs.readFileSync('./certs/ca.crt', 'utf8');
+const key = fs.readFileSync('./certs/client.key', 'utf8');
+
+// create your https.Agent
+const agent = https.Agent({
+    cert,
+    ca,
+    key,
+})
+
+const clientStub = new dgraph.DgraphClientStub('https://localhost:8080', false, {agent});
+const dgraphClient = new dgraph.DgraphClient(clientStub);
+```
+
 
 ### Alter the database
 

--- a/lib/clientStub.d.ts
+++ b/lib/clientStub.d.ts
@@ -1,12 +1,13 @@
-import { Assigned, Mutation, Operation, Payload, Request, Response, TxnContext, UiKeywords } from "./types";
+import { Assigned, Mutation, Operation, Options, Payload, Request, Response, TxnContext, UiKeywords } from "./types";
 export declare class DgraphClientStub {
     private readonly addr;
+    private readonly options;
     private legacyApi;
     private accessToken;
     private refreshToken;
     private autoRefresh;
     private autoRefreshTimer?;
-    constructor(addr?: string, legacyApi?: boolean);
+    constructor(addr?: string, legacyApi?: boolean, options?: Options);
     detectApiVersion(): Promise<string>;
     alter(op: Operation): Promise<Payload>;
     query(req: Request): Promise<Response>;

--- a/lib/clientStub.js
+++ b/lib/clientStub.js
@@ -1,4 +1,15 @@
 "use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -41,12 +52,18 @@ var jwt = require("jsonwebtoken");
 var errors_1 = require("./errors");
 var AUTO_REFRESH_PREFETCH_TIME = 5000;
 var DgraphClientStub = (function () {
-    function DgraphClientStub(addr, legacyApi) {
+    function DgraphClientStub(addr, legacyApi, options) {
         if (addr === undefined) {
             this.addr = "http://localhost:8080";
         }
         else {
             this.addr = addr;
+        }
+        if (options === undefined) {
+            this.options = {};
+        }
+        else {
+            this.options = options;
         }
         this.legacyApi = !!legacyApi;
     }
@@ -82,10 +99,7 @@ var DgraphClientStub = (function () {
         else {
             return Promise.reject("Invalid op argument in alter");
         }
-        return this.callAPI("alter", {
-            method: "POST",
-            body: body,
-        });
+        return this.callAPI("alter", __assign(__assign({}, this.options), { method: "POST", body: body }));
     };
     DgraphClientStub.prototype.query = function (req) {
         var headers = {};
@@ -155,11 +169,7 @@ var DgraphClientStub = (function () {
                     .join("&");
             }
         }
-        return this.callAPI(url, {
-            method: "POST",
-            body: req.query,
-            headers: headers,
-        });
+        return this.callAPI(url, __assign(__assign({}, this.options), { method: "POST", body: req.query, headers: headers }));
     };
     DgraphClientStub.prototype.mutate = function (mu) {
         var body;
@@ -222,11 +232,8 @@ var DgraphClientStub = (function () {
                 headers["X-Dgraph-CommitNow"] = "true";
             }
         }
-        return this.callAPI(url, {
-            method: "POST",
-            body: body,
-            headers: headers,
-        });
+        return this.callAPI(url, __assign(__assign({}, this.options), { method: "POST", body: body,
+            headers: headers }));
     };
     DgraphClientStub.prototype.commit = function (ctx) {
         var body;
@@ -239,16 +246,13 @@ var DgraphClientStub = (function () {
         var url = !this.legacyApi
             ? "commit?startTs=" + ctx.start_ts
             : "commit/" + ctx.start_ts;
-        return this.callAPI(url, {
-            method: "POST",
-            body: body,
-        });
+        return this.callAPI(url, __assign(__assign({}, this.options), { method: "POST", body: body }));
     };
     DgraphClientStub.prototype.abort = function (ctx) {
         var url = !this.legacyApi
             ? "commit?startTs=" + ctx.start_ts + "&abort=true"
             : "/abort/" + ctx.start_ts;
-        return this.callAPI(url, { method: "POST" });
+        return this.callAPI(url, __assign(__assign({}, this.options), { method: "POST" }));
     };
     DgraphClientStub.prototype.login = function (userid, password, refreshToken) {
         return __awaiter(this, void 0, void 0, function () {
@@ -300,7 +304,7 @@ var DgraphClientStub = (function () {
     DgraphClientStub.prototype.fetchUiKeywords = function () {
         return __awaiter(this, void 0, void 0, function () {
             return __generator(this, function (_a) {
-                return [2, this.callAPI("ui/keywords", {})];
+                return [2, this.callAPI("ui/keywords", this.options)];
             });
         });
     };
@@ -308,16 +312,14 @@ var DgraphClientStub = (function () {
         if (all === void 0) { all = false; }
         return __awaiter(this, void 0, void 0, function () {
             return __generator(this, function (_a) {
-                return [2, this.callAPI("health" + (all ? "?all" : ""), {
-                        acceptRawText: true,
-                    })];
+                return [2, this.callAPI("health" + (all ? "?all" : ""), __assign(__assign({}, this.options), { acceptRawText: true }))];
             });
         });
     };
     DgraphClientStub.prototype.getState = function () {
         return __awaiter(this, void 0, void 0, function () {
             return __generator(this, function (_a) {
-                return [2, this.callAPI("state", {})];
+                return [2, this.callAPI("state", this.options)];
             });
         });
     };

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+import * as https from "https";
 export interface Operation {
     schema?: string | null;
     dropAttr?: string | null;
@@ -75,4 +77,11 @@ export interface TxnOptions {
 }
 export interface ErrorNonJson extends Error {
     responseText?: string;
+}
+export interface Options extends https.RequestOptions {
+    agent?: https.Agent;
+}
+export interface Config extends Options {
+    acceptRawText?: boolean;
+    body?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import * as https from "https";
+
 export interface Operation {
     schema?: string | null;
     dropAttr?: string | null;
@@ -84,4 +86,12 @@ export interface TxnOptions {
 
 export interface ErrorNonJson extends Error {
     responseText?: string;
+}
+
+export interface Options extends https.RequestOptions {
+    agent?: https.Agent;
+}
+
+export interface Config extends Options {
+    body?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,5 +93,6 @@ export interface Options extends https.RequestOptions {
 }
 
 export interface Config extends Options {
+    acceptRawText?: boolean;
     body?: string;
 }


### PR DESCRIPTION
Our team has a need to connect to our dgraph cluster using mtls. Currently there was no way to pass any user defined options to `fetch`. This PR adds the ability to pass in additional options to the fetch call, including but not limited to an `https.Agent` to handle the SSL connection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js-http/26)
<!-- Reviewable:end -->
