### PR TITLE
Added support for custom headers

### DIFF
--- a/lib/client.d.ts
+++ b/lib/client.d.ts
@@ -11,6 +11,7 @@ export declare class DgraphClient {
     alter(op: Operation): Promise<Payload>;
     setAlphaAuthToken(authToken: string): void;
     setSlashApiKey(apiKey: string): void;
+    setCustomHeader(header: string, value: string): void;
     login(userid: string, password: string): Promise<boolean>;
     logout(): void;
     newTxn(options?: TxnOptions): Txn;

--- a/lib/client.js
+++ b/lib/client.js
@@ -78,6 +78,10 @@ var DgraphClient = (function () {
     DgraphClient.prototype.setSlashApiKey = function (apiKey) {
         this.clients.forEach(function (c) { return c.setSlashApiKey(apiKey); });
     };
+    DgraphClient.prototype.setCustomHeader = function (header, value) {
+        this.clients.forEach(function (c) { return c.setCustomHeader(header, value); });
+    };
+    ;
     DgraphClient.prototype.login = function (userid, password) {
         return __awaiter(this, void 0, void 0, function () {
             var c;

--- a/lib/clientStub.d.ts
+++ b/lib/clientStub.d.ts
@@ -30,6 +30,7 @@ export declare class DgraphClientStub {
     setAutoRefresh(val: boolean): void;
     setAlphaAuthToken(authToken: string): void;
     setSlashApiKey(apiKey: string): void;
+    setCustomHeader(header: string, value: string): void;
     private cancelRefreshTimer;
     private maybeStartRefreshTimer;
     private callAPI;

--- a/lib/clientStub.js
+++ b/lib/clientStub.js
@@ -66,6 +66,7 @@ var DgraphClientStub = (function () {
             this.addr = addr;
         }
         this.options = options;
+        this.options.header = {};
         this.legacyApi = !!stubConfig.legacyApi;
         this.jsonParser =
             stubConfig.jsonParser !== undefined
@@ -337,6 +338,9 @@ var DgraphClientStub = (function () {
     };
     DgraphClientStub.prototype.setSlashApiKey = function (apiKey) {
         this.options.headers[SLASH_API_KEY_HEADER] = apiKey;
+    };
+    DgraphClientStub.prototype.setCustomHeader = function (header, value) {
+        this.options.headers[header] = value;
     };
     DgraphClientStub.prototype.cancelRefreshTimer = function () {
         if (this.autoRefreshTimer !== undefined) {

--- a/lib/clientStub.js
+++ b/lib/clientStub.js
@@ -333,6 +333,7 @@ var DgraphClientStub = (function () {
         this.maybeStartRefreshTimer(this.accessToken);
     };
     DgraphClientStub.prototype.setAlphaAuthToken = function (authToken) {
+        this.options.headers === undefined && (this.options.headers = {});
         this.options.headers[ALPHA_AUTH_TOKEN_HEADER] = authToken;
     };
     DgraphClientStub.prototype.setSlashApiKey = function (apiKey) {

--- a/lib/clientStub.js
+++ b/lib/clientStub.js
@@ -1,6 +1,6 @@
 "use strict";
 var __assign = (this && this.__assign) || function () {
-    __assign = Object.assign || function (t) {
+    __assign = Object.assign || function(t) {
         for (var s, i = 1, n = arguments.length; i < n; i++) {
             s = arguments[i];
             for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
@@ -20,8 +20,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 var __generator = (this && this.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function () { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
-    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function () { return this; }), g;
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
     function verb(n) { return function (v) { return step([n, v]); }; }
     function step(op) {
         if (f) throw new TypeError("Generator is already executing.");
@@ -71,7 +71,7 @@ var DgraphClientStub = (function () {
             stubConfig.jsonParser !== undefined
                 ? stubConfig.jsonParser
                 :
-                JSON.parse.bind(JSON);
+                    JSON.parse.bind(JSON);
     }
     DgraphClientStub.prototype.detectApiVersion = function () {
         return __awaiter(this, void 0, void 0, function () {
@@ -170,9 +170,9 @@ var DgraphClientStub = (function () {
                 url += "?";
                 url += params
                     .map(function (_a) {
-                        var key = _a.key, value = _a.value;
-                        return key + "=" + value;
-                    })
+                    var key = _a.key, value = _a.value;
+                    return key + "=" + value;
+                })
                     .join("&");
             }
         }
@@ -197,8 +197,8 @@ var DgraphClientStub = (function () {
             body = "{\n                " + (mu.setNquads === undefined
                 ? ""
                 : "set {\n                    " + mu.setNquads + "\n                }") + "\n                " + (mu.deleteNquads === undefined
-                    ? ""
-                    : "delete {\n                    " + mu.deleteNquads + "\n                }") + "\n            }";
+                ? ""
+                : "delete {\n                    " + mu.deleteNquads + "\n                }") + "\n            }";
         }
         else if (mu.mutation !== undefined) {
             body = mu.mutation;
@@ -237,10 +237,8 @@ var DgraphClientStub = (function () {
                 headers["X-Dgraph-CommitNow"] = "true";
             }
         }
-        return this.callAPI(url, __assign(__assign({}, this.options), {
-            method: "POST", body: body,
-            headers: headers
-        }));
+        return this.callAPI(url, __assign(__assign({}, this.options), { method: "POST", body: body,
+            headers: headers }));
     };
     DgraphClientStub.prototype.commit = function (ctx) {
         var body;
@@ -335,6 +333,7 @@ var DgraphClientStub = (function () {
         this.maybeStartRefreshTimer(this.accessToken);
     };
     DgraphClientStub.prototype.setAlphaAuthToken = function (authToken) {
+        this.options.headers === undefined && (this.options.headers = {});
         this.options.headers[ALPHA_AUTH_TOKEN_HEADER] = authToken;
     };
     DgraphClientStub.prototype.setSlashApiKey = function (apiKey) {

--- a/lib/clientStub.js
+++ b/lib/clientStub.js
@@ -1,6 +1,6 @@
 "use strict";
 var __assign = (this && this.__assign) || function () {
-    __assign = Object.assign || function(t) {
+    __assign = Object.assign || function (t) {
         for (var s, i = 1, n = arguments.length; i < n; i++) {
             s = arguments[i];
             for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
@@ -20,8 +20,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 var __generator = (this && this.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
-    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    var _ = { label: 0, sent: function () { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function () { return this; }), g;
     function verb(n) { return function (v) { return step([n, v]); }; }
     function step(op) {
         if (f) throw new TypeError("Generator is already executing.");
@@ -71,7 +71,7 @@ var DgraphClientStub = (function () {
             stubConfig.jsonParser !== undefined
                 ? stubConfig.jsonParser
                 :
-                    JSON.parse.bind(JSON);
+                JSON.parse.bind(JSON);
     }
     DgraphClientStub.prototype.detectApiVersion = function () {
         return __awaiter(this, void 0, void 0, function () {
@@ -170,9 +170,9 @@ var DgraphClientStub = (function () {
                 url += "?";
                 url += params
                     .map(function (_a) {
-                    var key = _a.key, value = _a.value;
-                    return key + "=" + value;
-                })
+                        var key = _a.key, value = _a.value;
+                        return key + "=" + value;
+                    })
                     .join("&");
             }
         }
@@ -197,8 +197,8 @@ var DgraphClientStub = (function () {
             body = "{\n                " + (mu.setNquads === undefined
                 ? ""
                 : "set {\n                    " + mu.setNquads + "\n                }") + "\n                " + (mu.deleteNquads === undefined
-                ? ""
-                : "delete {\n                    " + mu.deleteNquads + "\n                }") + "\n            }";
+                    ? ""
+                    : "delete {\n                    " + mu.deleteNquads + "\n                }") + "\n            }";
         }
         else if (mu.mutation !== undefined) {
             body = mu.mutation;
@@ -237,8 +237,10 @@ var DgraphClientStub = (function () {
                 headers["X-Dgraph-CommitNow"] = "true";
             }
         }
-        return this.callAPI(url, __assign(__assign({}, this.options), { method: "POST", body: body,
-            headers: headers }));
+        return this.callAPI(url, __assign(__assign({}, this.options), {
+            method: "POST", body: body,
+            headers: headers
+        }));
     };
     DgraphClientStub.prototype.commit = function (ctx) {
         var body;
@@ -333,7 +335,6 @@ var DgraphClientStub = (function () {
         this.maybeStartRefreshTimer(this.accessToken);
     };
     DgraphClientStub.prototype.setAlphaAuthToken = function (authToken) {
-        this.options.headers === undefined && (this.options.headers = {});
         this.options.headers[ALPHA_AUTH_TOKEN_HEADER] = authToken;
     };
     DgraphClientStub.prototype.setSlashApiKey = function (apiKey) {

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -80,6 +80,7 @@ export interface ErrorNonJson extends Error {
 }
 export interface Options extends https.RequestOptions {
     agent?: https.Agent;
+    header?: {};
 }
 export interface Config extends Options {
     acceptRawText?: boolean;

--- a/src/client.ts
+++ b/src/client.ts
@@ -63,6 +63,10 @@ export class DgraphClient {
         this.clients.forEach((c: DgraphClientStub) => c.setSlashApiKey(apiKey));
     }
 
+    public setCustomHeader (header: string, value: string) {
+        this.clients.forEach((c: DgraphClientStub) => c.setCustomHeader(header, value));
+    };
+
     /**
      * login obtains access tokens from Dgraph Server
      */

--- a/src/clientStub.ts
+++ b/src/clientStub.ts
@@ -372,6 +372,7 @@ export class DgraphClientStub {
     }
 
     public setAlphaAuthToken(authToken: string) {
+        this.options.headers === undefined && (this.options.headers = {});
         this.options.headers[ALPHA_AUTH_TOKEN_HEADER] = authToken;
     }
 

--- a/src/clientStub.ts
+++ b/src/clientStub.ts
@@ -372,12 +372,18 @@ export class DgraphClientStub {
     }
 
     public setAlphaAuthToken(authToken: string) {
+        if(this.options.headers === undefined) this.options.headers={};
         this.options.headers[ALPHA_AUTH_TOKEN_HEADER] = authToken;
     }
 
     public setSlashApiKey(apiKey: string) {
+        if(this.options.headers === undefined) this.options.headers={};
         this.options.headers[SLASH_API_KEY_HEADER] = apiKey;
     }
+    public setCustomHeader(header: string, value: string) {
+        if(this.options.headers === undefined) this.options.headers={};
+        this.options.headers[header] = value;
+    };
 
     private cancelRefreshTimer() {
         if (this.autoRefreshTimer !== undefined) {

--- a/src/clientStub.ts
+++ b/src/clientStub.ts
@@ -55,7 +55,7 @@ export class DgraphClientStub {
         }
 
         this.options = options;
-
+        this.options.header = {};
         this.legacyApi = !!stubConfig.legacyApi;
         this.jsonParser =
             stubConfig.jsonParser !== undefined
@@ -372,18 +372,15 @@ export class DgraphClientStub {
     }
 
     public setAlphaAuthToken(authToken: string) {
-        if(this.options.headers === undefined) this.options.headers={};
         this.options.headers[ALPHA_AUTH_TOKEN_HEADER] = authToken;
     }
 
     public setSlashApiKey(apiKey: string) {
-        if(this.options.headers === undefined) this.options.headers={};
         this.options.headers[SLASH_API_KEY_HEADER] = apiKey;
     }
     public setCustomHeader(header: string, value: string) {
-        if(this.options.headers === undefined) this.options.headers={};
         this.options.headers[header] = value;
-    };
+    }
 
     private cancelRefreshTimer() {
         if (this.autoRefreshTimer !== undefined) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,7 @@ export interface ErrorNonJson extends Error {
 
 export interface Options extends https.RequestOptions {
     agent?: https.Agent;
+    header?: {};
 }
 
 export interface Config extends Options {


### PR DESCRIPTION
Added support for adding custom headers after creating a ClientStub object. 

**Reason**
To be able to add headers such as auth tokens from third party authentication services that may not necessarily be available at the time of creation of the ClientStub and Client object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js-http/32)
<!-- Reviewable:end -->
