### PR TITLE
bugfix: txn failing on large arrays

### DIFF
--- a/lib/txn.js
+++ b/lib/txn.js
@@ -198,8 +198,7 @@ var Txn = (function () {
         });
     };
     Txn.prototype.mergeArrays = function (a, b) {
-        var res = a.slice();
-        res.push.apply(res, b);
+        var res = a.slice().concat(b);
         res.sort();
         return res.filter(function (item, idx, arr) { return idx === 0 || arr[idx - 1] !== item; });
     };

--- a/src/txn.ts
+++ b/src/txn.ts
@@ -200,8 +200,7 @@ export class Txn {
     }
 
     private mergeArrays(a: string[], b: string[]) {
-        const res = a.slice();
-        res.push(...b);
+        const res = a.slice().concat(b);
         res.sort();
         // Filter unique in a sorted array.
         return res.filter(


### PR DESCRIPTION
I've noticed that mutations containing very large amounts of data are likely to fail with `RangeError: Maximum call stack size exceeded`. The reason is obviously the line `res.push.apply(res, b);` in the compiled JS. This commit fixes that issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js-http/33)
<!-- Reviewable:end -->
