### PR TITLE
Fix issue where setSlashApiKey would break if no headers was set.

### DIFF
--- a/src/clientStub.ts
+++ b/src/clientStub.ts
@@ -377,6 +377,7 @@ export class DgraphClientStub {
     }
 
     public setSlashApiKey(apiKey: string) {
+        this.options.headers === undefined && (this.options.headers = {});
         this.options.headers[SLASH_API_KEY_HEADER] = apiKey;
     }
 


### PR DESCRIPTION
Hi Team,

See https://discuss.dgraph.io/t/dgraph-js-http-setslashapikey-breaks/11250


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js-http/34)
<!-- Reviewable:end -->
