### PR TITLE
chore: Txn & deprecate Slash endpoint method

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -76,7 +76,6 @@ var DgraphClient = (function () {
         });
     };
     DgraphClient.prototype.setSlashApiKey = function (apiKey) {
-        console.warn("This method is deprecated and will be removed in v21.07 release.");
         this.clients.forEach(function (c) { return c.setSlashApiKey(apiKey); });
     };
     DgraphClient.prototype.login = function (userid, password) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -76,6 +76,7 @@ var DgraphClient = (function () {
         });
     };
     DgraphClient.prototype.setSlashApiKey = function (apiKey) {
+        console.warn("This method is deprecated and will be removed in v21.07 release.");
         this.clients.forEach(function (c) { return c.setSlashApiKey(apiKey); });
     };
     DgraphClient.prototype.login = function (userid, password) {

--- a/lib/clientStub.js
+++ b/lib/clientStub.js
@@ -399,7 +399,6 @@ var DgraphClientStub = (function () {
         this.options.headers[ALPHA_AUTH_TOKEN_HEADER] = authToken;
     };
     DgraphClientStub.prototype.setSlashApiKey = function (apiKey) {
-        console.warn("This method is deprecated and will be removed in v21.07 release.");
         if (this.options.headers === undefined) {
             this.options.headers = {};
         }

--- a/lib/clientStub.js
+++ b/lib/clientStub.js
@@ -108,6 +108,7 @@ var DgraphClientStub = (function () {
         return this.callAPI("alter", __assign(__assign({}, this.options), { method: "POST", body: body }));
     };
     DgraphClientStub.prototype.query = function (req) {
+        var _a;
         var headers = this.options.headers !== undefined
             ? __assign({}, this.options.headers) : {};
         if (req.vars !== undefined) {
@@ -166,7 +167,7 @@ var DgraphClientStub = (function () {
                     value: "true",
                 });
             }
-            if ((req === null || req === void 0 ? void 0 : req.hash.length) > 0) {
+            if (((_a = req === null || req === void 0 ? void 0 : req.hash) === null || _a === void 0 ? void 0 : _a.length) > 0) {
                 params.push({
                     key: "hash",
                     value: "" + req.hash,
@@ -185,6 +186,7 @@ var DgraphClientStub = (function () {
         return this.callAPI(url, __assign(__assign({}, this.options), { method: "POST", body: req.query, headers: headers }));
     };
     DgraphClientStub.prototype.mutate = function (mu) {
+        var _a;
         var body;
         var usingJSON = false;
         if (mu.setJson !== undefined || mu.deleteJson !== undefined) {
@@ -235,7 +237,7 @@ var DgraphClientStub = (function () {
                 (!this.legacyApi ? "?startTs=" : "/") + mu.startTs.toString();
             nextDelim = "&";
         }
-        if ((mu === null || mu === void 0 ? void 0 : mu.hash.length) > 0) {
+        if (((_a = mu === null || mu === void 0 ? void 0 : mu.hash) === null || _a === void 0 ? void 0 : _a.length) > 0) {
             if (!this.legacyApi) {
                 url += nextDelim + "hash=" + mu.hash;
             }
@@ -252,6 +254,7 @@ var DgraphClientStub = (function () {
             headers: headers }));
     };
     DgraphClientStub.prototype.commit = function (ctx) {
+        var _a;
         var body;
         if (ctx.keys === undefined) {
             body = "[]";
@@ -262,7 +265,7 @@ var DgraphClientStub = (function () {
         var url = !this.legacyApi
             ? "commit?startTs=" + ctx.start_ts
             : "commit/" + ctx.start_ts;
-        if ((ctx === null || ctx === void 0 ? void 0 : ctx.hash.length) > 0) {
+        if (((_a = ctx === null || ctx === void 0 ? void 0 : ctx.hash) === null || _a === void 0 ? void 0 : _a.length) > 0) {
             if (!this.legacyApi) {
                 url += "&hash=" + ctx.hash;
             }
@@ -270,10 +273,11 @@ var DgraphClientStub = (function () {
         return this.callAPI(url, __assign(__assign({}, this.options), { method: "POST", body: body }));
     };
     DgraphClientStub.prototype.abort = function (ctx) {
+        var _a;
         var url = !this.legacyApi
             ? "commit?startTs=" + ctx.start_ts + "&abort=true"
             : "abort/" + ctx.start_ts;
-        if ((ctx === null || ctx === void 0 ? void 0 : ctx.hash.length) > 0) {
+        if (((_a = ctx === null || ctx === void 0 ? void 0 : ctx.hash) === null || _a === void 0 ? void 0 : _a.length) > 0) {
             if (!this.legacyApi) {
                 url += "&hash=" + ctx.hash;
             }

--- a/lib/clientStub.js
+++ b/lib/clientStub.js
@@ -166,6 +166,12 @@ var DgraphClientStub = (function () {
                     value: "true",
                 });
             }
+            if ((req === null || req === void 0 ? void 0 : req.hash.length) > 0) {
+                params.push({
+                    key: "hash",
+                    value: "" + req.hash,
+                });
+            }
             if (params.length > 0) {
                 url += "?";
                 url += params
@@ -229,6 +235,11 @@ var DgraphClientStub = (function () {
                 (!this.legacyApi ? "?startTs=" : "/") + mu.startTs.toString();
             nextDelim = "&";
         }
+        if ((mu === null || mu === void 0 ? void 0 : mu.hash.length) > 0) {
+            if (!this.legacyApi) {
+                url += nextDelim + "hash=" + mu.hash;
+            }
+        }
         if (mu.commitNow) {
             if (!this.legacyApi) {
                 url += nextDelim + "commitNow=true";
@@ -251,12 +262,22 @@ var DgraphClientStub = (function () {
         var url = !this.legacyApi
             ? "commit?startTs=" + ctx.start_ts
             : "commit/" + ctx.start_ts;
+        if ((ctx === null || ctx === void 0 ? void 0 : ctx.hash.length) > 0) {
+            if (!this.legacyApi) {
+                url += "&hash=" + ctx.hash;
+            }
+        }
         return this.callAPI(url, __assign(__assign({}, this.options), { method: "POST", body: body }));
     };
     DgraphClientStub.prototype.abort = function (ctx) {
         var url = !this.legacyApi
             ? "commit?startTs=" + ctx.start_ts + "&abort=true"
             : "abort/" + ctx.start_ts;
+        if ((ctx === null || ctx === void 0 ? void 0 : ctx.hash.length) > 0) {
+            if (!this.legacyApi) {
+                url += "&hash=" + ctx.hash;
+            }
+        }
         return this.callAPI(url, __assign(__assign({}, this.options), { method: "POST" }));
     };
     DgraphClientStub.prototype.login = function (userid, password, refreshToken) {
@@ -374,6 +395,7 @@ var DgraphClientStub = (function () {
         this.options.headers[ALPHA_AUTH_TOKEN_HEADER] = authToken;
     };
     DgraphClientStub.prototype.setSlashApiKey = function (apiKey) {
+        console.warn("This method is deprecated and will be removed in v21.07 release.");
         if (this.options.headers === undefined) {
             this.options.headers = {};
         }

--- a/lib/txn.js
+++ b/lib/txn.js
@@ -55,6 +55,7 @@ var Txn = (function () {
             preds: [],
             readOnly: options.readOnly,
             bestEffort: options.bestEffort,
+            hash: "",
         };
     }
     Txn.prototype.query = function (q, options) {
@@ -78,6 +79,7 @@ var Txn = (function () {
                             debug: options.debug,
                             readOnly: this.ctx.readOnly,
                             bestEffort: this.ctx.bestEffort,
+                            hash: this.ctx.hash,
                         };
                         if (vars !== undefined) {
                             varsObj_1 = {};
@@ -113,6 +115,7 @@ var Txn = (function () {
                         }
                         this.mutated = true;
                         mu.startTs = this.ctx.start_ts;
+                        mu.hash = this.ctx.hash;
                         this.dc.debug("Mutate request:\n" + util_1.stringifyMessage(mu));
                         c = this.dc.anyClient();
                         _a.label = 1;
@@ -203,9 +206,11 @@ var Txn = (function () {
         return res.filter(function (item, idx, arr) { return idx === 0 || arr[idx - 1] !== item; });
     };
     Txn.prototype.mergeContext = function (src) {
+        var _a;
         if (src === undefined) {
             return;
         }
+        this.ctx.hash = (_a = src.hash) !== null && _a !== void 0 ? _a : "";
         if (this.ctx.start_ts === 0) {
             this.ctx.start_ts = src.start_ts;
         }

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -18,6 +18,7 @@ export interface Request {
     debug?: boolean;
     readOnly?: boolean;
     bestEffort?: boolean;
+    hash?: string;
 }
 export interface Response {
     data: {};
@@ -44,6 +45,7 @@ export interface Mutation {
     commitNow?: boolean;
     mutation?: string;
     isJsonString?: boolean;
+    hash?: string;
 }
 export interface Assigned {
     data: AssignedData;
@@ -65,6 +67,7 @@ export interface TxnContext {
     preds?: string[];
     readOnly: boolean;
     bestEffort: boolean;
+    hash?: string;
 }
 export interface Latency {
     parsing_ns?: number;

--- a/src/client.ts
+++ b/src/client.ts
@@ -60,11 +60,11 @@ export class DgraphClient {
     }
 
     /**
-     * @deprecated since v21.3 and will be removed in v21.07 release.
+     * @deprecated since v21.3 and will be removed in v21.07 release. For more details, see:
+     *     https://discuss.dgraph.io/t/regarding-slash-cloud-dgraph-endpoints-in-the-clients/13492
      */
 
     public setSlashApiKey(apiKey: string) {
-        console.warn("This method is deprecated and will be removed in v21.07 release.");
         this.clients.forEach((c: DgraphClientStub) => c.setSlashApiKey(apiKey));
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -59,7 +59,12 @@ export class DgraphClient {
         );
     }
 
+    /**
+     * @deprecated since v21.3 and will be removed in v21.07 release.
+     */
+
     public setSlashApiKey(apiKey: string) {
+        console.warn("This method is deprecated and will be removed in v21.07 release.");
         this.clients.forEach((c: DgraphClientStub) => c.setSlashApiKey(apiKey));
     }
 

--- a/src/clientStub.ts
+++ b/src/clientStub.ts
@@ -444,11 +444,11 @@ export class DgraphClientStub {
     }
 
     /**
-     * @deprecated since v21.3 and will be removed in v21.07 release.
+     * @deprecated since v21.3 and will be removed in v21.07 release. For more details, see:
+     *     https://discuss.dgraph.io/t/regarding-slash-cloud-dgraph-endpoints-in-the-clients/13492
      */
 
     public setSlashApiKey(apiKey: string) {
-        console.warn("This method is deprecated and will be removed in v21.07 release.");
         if (this.options.headers === undefined) {
             this.options.headers = {};
         }

--- a/src/clientStub.ts
+++ b/src/clientStub.ts
@@ -155,7 +155,7 @@ export class DgraphClientStub {
                     value: "true",
                 });
             }
-            if (req?.hash.length > 0) {
+            if (req?.hash?.length > 0) {
                 params.push({
                     key: "hash",
                     value: `${req.hash}`,
@@ -254,7 +254,7 @@ export class DgraphClientStub {
             nextDelim = "&";
         }
 
-        if (mu?.hash.length > 0) {
+        if (mu?.hash?.length > 0) {
             if (!this.legacyApi) {
                 url += `${nextDelim}hash=${mu.hash}`;
             }
@@ -288,7 +288,7 @@ export class DgraphClientStub {
             ? `commit?startTs=${ctx.start_ts}`
             : `commit/${ctx.start_ts}`;
 
-        if (ctx?.hash.length > 0) {
+        if (ctx?.hash?.length > 0) {
             if (!this.legacyApi) {
                 url += `&hash=${ctx.hash}`;
             }
@@ -306,7 +306,7 @@ export class DgraphClientStub {
             ? `commit?startTs=${ctx.start_ts}&abort=true`
             : `abort/${ctx.start_ts}`;
 
-       if (ctx?.hash.length > 0) {
+       if (ctx?.hash?.length > 0) {
            if (!this.legacyApi) {
                 url += `&hash=${ctx.hash}`;
            }

--- a/src/clientStub.ts
+++ b/src/clientStub.ts
@@ -155,6 +155,12 @@ export class DgraphClientStub {
                     value: "true",
                 });
             }
+            if (req?.hash.length > 0) {
+                params.push({
+                    key: "hash",
+                    value: `${req.hash}`,
+                });
+            }
             if (params.length > 0) {
                 url += "?";
                 url += params
@@ -248,6 +254,12 @@ export class DgraphClientStub {
             nextDelim = "&";
         }
 
+        if (mu?.hash.length > 0) {
+            if (!this.legacyApi) {
+                url += `${nextDelim}hash=${mu.hash}`;
+            }
+        }
+
         if (mu.commitNow) {
             if (!this.legacyApi) {
                 url += `${nextDelim}commitNow=true`;
@@ -272,9 +284,15 @@ export class DgraphClientStub {
             body = JSON.stringify(ctx.keys);
         }
 
-        const url = !this.legacyApi
+        let url = !this.legacyApi
             ? `commit?startTs=${ctx.start_ts}`
             : `commit/${ctx.start_ts}`;
+
+        if (ctx?.hash.length > 0) {
+            if (!this.legacyApi) {
+                url += `&hash=${ctx.hash}`;
+            }
+        }
 
         return this.callAPI(url, {
             ...this.options,
@@ -284,11 +302,17 @@ export class DgraphClientStub {
     }
 
     public abort(ctx: TxnContext): Promise<TxnContext> {
-        const url = !this.legacyApi
+       let  url = !this.legacyApi
             ? `commit?startTs=${ctx.start_ts}&abort=true`
             : `abort/${ctx.start_ts}`;
 
-        return this.callAPI(url, { ...this.options, method: "POST" });
+       if (ctx?.hash.length > 0) {
+           if (!this.legacyApi) {
+                url += `&hash=${ctx.hash}`;
+           }
+       }
+
+       return this.callAPI(url, { ...this.options, method: "POST" });
     }
 
     public async login(
@@ -419,7 +443,12 @@ export class DgraphClientStub {
         this.options.headers[ALPHA_AUTH_TOKEN_HEADER] = authToken;
     }
 
+    /**
+     * @deprecated since v21.3 and will be removed in v21.07 release.
+     */
+
     public setSlashApiKey(apiKey: string) {
+        console.warn("This method is deprecated and will be removed in v21.07 release.");
         if (this.options.headers === undefined) {
             this.options.headers = {};
         }

--- a/src/txn.ts
+++ b/src/txn.ts
@@ -41,6 +41,7 @@ export class Txn {
           preds: [],
           readOnly: options.readOnly,
           bestEffort: options.bestEffort,
+          hash: "",
         };
     }
 
@@ -74,6 +75,7 @@ export class Txn {
             debug: options.debug,
             readOnly: this.ctx.readOnly,
             bestEffort: this.ctx.bestEffort,
+            hash: this.ctx.hash,
         };
         if (vars !== undefined) {
             const varsObj: { [k: string]: string } = {};
@@ -117,6 +119,7 @@ export class Txn {
 
         this.mutated = true;
         mu.startTs = this.ctx.start_ts;
+        mu.hash = this.ctx.hash;
         this.dc.debug(`Mutate request:\n${stringifyMessage(mu)}`);
 
         const c = this.dc.anyClient();
@@ -212,6 +215,8 @@ export class Txn {
             // This condition will be true only if the server doesn't return a txn context after a query or mutation.
             return;
         }
+
+        this.ctx.hash = src.hash ?? "" ;
 
         if (this.ctx.start_ts === 0) {
             this.ctx.start_ts = src.start_ts;

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface Request {
     debug?: boolean;
     readOnly?: boolean;
     bestEffort?: boolean;
+    hash?: string;
 }
 
 export interface Response {
@@ -48,6 +49,7 @@ export interface Mutation {
     mutation?: string;
     // Set to true if `mutation` field (above) contains a JSON mutation.
     isJsonString?: boolean;
+    hash?: string;
 }
 
 export interface Assigned {
@@ -71,6 +73,7 @@ export interface TxnContext {
     preds?: string[];
     readOnly: boolean;
     bestEffort: boolean;
+    hash?: string;
 }
 
 export interface Latency {

--- a/tslint.json
+++ b/tslint.json
@@ -9,6 +9,7 @@
     "no-relative-imports": false,
     "import-name": false,
     "export-name": false,
+    "cyclomatic-complexity": false,
     "promise-function-async": false,
     "no-void-expression": false,
     "newline-before-return": false,


### PR DESCRIPTION
* Make transaction context more robust.
* Deprecate `setSlashApiKey` method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js-http/43)
<!-- Reviewable:end -->
