### PR TITLE
fix(deprecation): add setCloudApiKey method

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ const clientStub = new dgraph.DgraphClientStub(
 const dgraphClient = new dgraph.DgraphClient(clientStub);
 
 //here we pass the API key
-dgraphClient.setSlashApiKey("<api-key>");
+dgraphClient.setCloudApiKey("<api-key>");
 ```
 
-**Note:** the `setSlashApiKey` method is deprecated and will be removed in the next release.
+**Note:** the `setSlashApiKey` method is deprecated and will be removed in the next release. Instead use `setCloudApiKey` method.
 
 ### Login into Dgraph
 
@@ -166,10 +166,10 @@ Some Dgraph configurations require extra access tokens.
 dgraphClient.setAlphaAuthToken("My secret token value");
 ```
 
-2. [Slash GraphQL](https://dgraph.io/slash-graphql) requires API key for HTTP access:
+2. [Dgraph Cloud](https://cloud.dgraph.io) requires API key for HTTP access:
 
 ```js
-dgraphClient.setSlashApiKey("Copy the Api Key from Slash GraphQL admin page");
+dgraphClient.setCloudApiKey("Copy the Api Key from Dgraph Cloud admin page");
 ```
 
 ### Create https connection

--- a/lib/client.d.ts
+++ b/lib/client.d.ts
@@ -11,6 +11,7 @@ export declare class DgraphClient {
     alter(op: Operation): Promise<Payload>;
     setAlphaAuthToken(authToken: string): void;
     setSlashApiKey(apiKey: string): void;
+    setCloudApiKey(apiKey: string): void;
     login(userid: string, password: string): Promise<boolean>;
     loginIntoNamespace(userid: string, password: string, namespace?: number): Promise<boolean>;
     logout(): void;

--- a/lib/client.js
+++ b/lib/client.js
@@ -76,7 +76,10 @@ var DgraphClient = (function () {
         });
     };
     DgraphClient.prototype.setSlashApiKey = function (apiKey) {
-        this.clients.forEach(function (c) { return c.setSlashApiKey(apiKey); });
+        this.setCloudApiKey(apiKey);
+    };
+    DgraphClient.prototype.setCloudApiKey = function (apiKey) {
+        this.clients.forEach(function (c) { return c.setCloudApiKey(apiKey); });
     };
     DgraphClient.prototype.login = function (userid, password) {
         return __awaiter(this, void 0, void 0, function () {

--- a/lib/clientStub.d.ts
+++ b/lib/clientStub.d.ts
@@ -31,6 +31,7 @@ export declare class DgraphClientStub {
     setAutoRefresh(val: boolean): void;
     setAlphaAuthToken(authToken: string): void;
     setSlashApiKey(apiKey: string): void;
+    setCloudApiKey(apiKey: string): void;
     private cancelRefreshTimer;
     private maybeStartRefreshTimer;
     private callAPI;

--- a/lib/clientStub.js
+++ b/lib/clientStub.js
@@ -54,7 +54,7 @@ var errors_1 = require("./errors");
 var AUTO_REFRESH_PREFETCH_TIME = 5000;
 var ACL_TOKEN_HEADER = "X-Dgraph-AccessToken";
 var ALPHA_AUTH_TOKEN_HEADER = "X-Dgraph-AuthToken";
-var SLASH_API_KEY_HEADER = "X-Auth-Token";
+var DGRAPHCLOUD_API_KEY_HEADER = "X-Auth-Token";
 var DgraphClientStub = (function () {
     function DgraphClientStub(addr, stubConfig, options) {
         if (stubConfig === void 0) { stubConfig = {}; }
@@ -399,10 +399,13 @@ var DgraphClientStub = (function () {
         this.options.headers[ALPHA_AUTH_TOKEN_HEADER] = authToken;
     };
     DgraphClientStub.prototype.setSlashApiKey = function (apiKey) {
+        this.setCloudApiKey(apiKey);
+    };
+    DgraphClientStub.prototype.setCloudApiKey = function (apiKey) {
         if (this.options.headers === undefined) {
             this.options.headers = {};
         }
-        this.options.headers[SLASH_API_KEY_HEADER] = apiKey;
+        this.options.headers[DGRAPHCLOUD_API_KEY_HEADER] = apiKey;
     };
     DgraphClientStub.prototype.cancelRefreshTimer = function () {
         if (this.autoRefreshTimer !== undefined) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -60,12 +60,16 @@ export class DgraphClient {
     }
 
     /**
-     * @deprecated since v21.3 and will be removed in v21.07 release. For more details, see:
-     *     https://discuss.dgraph.io/t/regarding-slash-cloud-dgraph-endpoints-in-the-clients/13492
+     * @deprecated since v21.3 and will be removed in v21.07 release.
+     *     Please use {@link setCloudApiKey} instead.
      */
 
     public setSlashApiKey(apiKey: string) {
-        this.clients.forEach((c: DgraphClientStub) => c.setSlashApiKey(apiKey));
+        this.setCloudApiKey(apiKey);
+    }
+
+    public setCloudApiKey(apiKey: string) {
+        this.clients.forEach((c: DgraphClientStub) => c.setCloudApiKey(apiKey));
     }
 
     /**

--- a/src/clientStub.ts
+++ b/src/clientStub.ts
@@ -22,7 +22,7 @@ const AUTO_REFRESH_PREFETCH_TIME = 5000;
 
 const ACL_TOKEN_HEADER = "X-Dgraph-AccessToken";
 const ALPHA_AUTH_TOKEN_HEADER = "X-Dgraph-AuthToken";
-const SLASH_API_KEY_HEADER = "X-Auth-Token";
+const DGRAPHCLOUD_API_KEY_HEADER = "X-Auth-Token";
 
 /**
  * Stub is a stub/client connecting to a single dgraph server instance.
@@ -302,17 +302,17 @@ export class DgraphClientStub {
     }
 
     public abort(ctx: TxnContext): Promise<TxnContext> {
-       let  url = !this.legacyApi
+        let url = !this.legacyApi
             ? `commit?startTs=${ctx.start_ts}&abort=true`
             : `abort/${ctx.start_ts}`;
 
-       if (ctx?.hash?.length > 0) {
-           if (!this.legacyApi) {
+        if (ctx?.hash?.length > 0) {
+            if (!this.legacyApi) {
                 url += `&hash=${ctx.hash}`;
-           }
-       }
+            }
+        }
 
-       return this.callAPI(url, { ...this.options, method: "POST" });
+        return this.callAPI(url, { ...this.options, method: "POST" });
     }
 
     public async login(
@@ -320,38 +320,38 @@ export class DgraphClientStub {
         password?: string,
         refreshToken?: string,
     ): Promise<boolean> {
-         if (this.legacyApi) {
-             throw new Error("Pre v1.1 clients do not support Login methods");
-         }
+        if (this.legacyApi) {
+            throw new Error("Pre v1.1 clients do not support Login methods");
+        }
 
-         const body: { [k: string]: string } = {};
-         if (
-             userid === undefined &&
-             refreshToken === undefined &&
-             this.refreshToken === undefined
-         ) {
-             throw new Error(
-                 "Cannot find login details: neither userid/password nor refresh token are specified",
-             );
-         }
-         if (userid === undefined) {
-             body.refresh_token =
-                 refreshToken !== undefined ? refreshToken : this.refreshToken;
-         } else {
-             body.userid = userid;
-             body.password = password;
-         }
+        const body: { [k: string]: string } = {};
+        if (
+            userid === undefined &&
+            refreshToken === undefined &&
+            this.refreshToken === undefined
+        ) {
+            throw new Error(
+                "Cannot find login details: neither userid/password nor refresh token are specified",
+            );
+        }
+        if (userid === undefined) {
+            body.refresh_token =
+                refreshToken !== undefined ? refreshToken : this.refreshToken;
+        } else {
+            body.userid = userid;
+            body.password = password;
+        }
 
-         const res: LoginResponse = await this.callAPI("login", {
-             ...this.options,
-             method: "POST",
-             body: JSON.stringify(body),
-         });
-         this.accessToken = res.data.accessJWT;
-         this.refreshToken = res.data.refreshJWT;
+        const res: LoginResponse = await this.callAPI("login", {
+            ...this.options,
+            method: "POST",
+            body: JSON.stringify(body),
+        });
+        this.accessToken = res.data.accessJWT;
+        this.refreshToken = res.data.refreshJWT;
 
-         this.maybeStartRefreshTimer(this.accessToken);
-         return true;
+        this.maybeStartRefreshTimer(this.accessToken);
+        return true;
     }
 
     public async loginIntoNamespace(
@@ -444,15 +444,19 @@ export class DgraphClientStub {
     }
 
     /**
-     * @deprecated since v21.3 and will be removed in v21.07 release. For more details, see:
-     *     https://discuss.dgraph.io/t/regarding-slash-cloud-dgraph-endpoints-in-the-clients/13492
+     * @deprecated since v21.3 and will be removed in v21.07 release.
+     *     Please use {@link setCloudApiKey} instead.
      */
 
     public setSlashApiKey(apiKey: string) {
+        this.setCloudApiKey(apiKey);
+    }
+
+    public setCloudApiKey(apiKey: string) {
         if (this.options.headers === undefined) {
             this.options.headers = {};
         }
-        this.options.headers[SLASH_API_KEY_HEADER] = apiKey;
+        this.options.headers[DGRAPHCLOUD_API_KEY_HEADER] = apiKey;
     }
 
     private cancelRefreshTimer() {


### PR DESCRIPTION
This PR adds `setCloudApiKey` and makes `setSlashApiKey` deprecated method to use it instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js-http/47)
<!-- Reviewable:end -->
