### PR TITLE
examples(latency): Add example to calculate client and server latency.

### DIFF
--- a/examples/latency/index-async-await.js
+++ b/examples/latency/index-async-await.js
@@ -110,6 +110,7 @@ async function queryData(dgraphClient) {
     }`;
     const vars = { $a: "Alice" };
 
+    console.log("Query:", query.replace(/[\t\n ]+/gm, " "), "Vars:", vars);
     console.time('Query client latency');
     const res = await dgraphClient.newTxn().queryWithVars(query, vars);
     console.timeEnd('Query client latency');

--- a/examples/latency/index-async-await.js
+++ b/examples/latency/index-async-await.js
@@ -1,0 +1,149 @@
+const dgraph = require("dgraph-js-http");
+const minimist = require("minimist");
+
+// Create a client stub.
+function newClientStub(addr) {
+    return new dgraph.DgraphClientStub(addr);
+}
+
+// Create a client.
+function newClient(clientStub, apiKey) {
+    c = new dgraph.DgraphClient(clientStub);
+    if (apiKey != "") {
+        c.setSlashApiKey(apiKey);
+    }
+    return c;
+}
+
+// Drop All - discard all data and start from a clean slate.
+async function dropAll(dgraphClient) {
+    await dgraphClient.alter({ dropAll: true });
+}
+
+// Set schema.
+async function setSchema(dgraphClient) {
+    const schema = `
+        name: string @index(exact) .
+        age: int .
+        married: bool .
+        loc: geo .
+        dob: datetime .
+    `;
+    await dgraphClient.alter({ schema: schema });
+}
+
+// Create data using JSON.
+async function createData(dgraphClient) {
+    // Create a new transaction.
+    const txn = dgraphClient.newTxn();
+    try {
+        // Create data.
+        const p = {
+            uid: "_:blank-0",
+            name: "Alice",
+            age: 26,
+            married: true,
+            loc: {
+                type: "Point",
+                coordinates: [1.1, 2],
+            },
+            dob: new Date(1980, 1, 1, 23, 0, 0, 0),
+            friend: [
+                {
+                    name: "Bob",
+                    age: 24,
+                },
+                {
+                    name: "Charlie",
+                    age: 29,
+                }
+            ],
+            school: [
+                {
+                    name: "Crown Public School",
+                }
+            ]
+        };
+
+        // Run mutation.
+        const assigned = await txn.mutate({ setJson: p });
+
+        // Commit transaction.
+        await txn.commit();
+
+        // Get uid of the outermost object (person named "Alice").
+        // Assigned#getUidsMap() returns a map from blank node names to uids.
+        // For a json mutation, blank node names "blank-0", "blank-1", ... are used
+        // for all the created nodes.
+        console.log(`Created person named "Alice" with uid = ${assigned.data.uids["blank-0"]}\n`);
+
+        console.log("All created nodes (map from blank node names to uids):");
+        Object.keys(assigned.data.uids).forEach((key) => console.log(`${key} => ${assigned.data.uids[key]}`));
+        console.log();
+    } finally {
+        // Clean up. Calling this after txn.commit() is a no-op
+        // and hence safe.
+        await txn.discard();
+    }
+}
+
+// Query for data.
+async function queryData(dgraphClient) {
+    // Run query.
+    const query = `query all($a: string) {
+        all(func: eq(name, $a)) {
+            uid
+            name
+            age
+            married
+            loc
+            dob
+            friend {
+                name
+                age
+            }
+            school {
+                name
+            }
+        }
+    }`;
+    const vars = { $a: "Alice" };
+
+    console.time('Query client latency');
+    const res = await dgraphClient.newTxn().queryWithVars(query, vars);
+    console.timeEnd('Query client latency');
+    console.log("Query server latency:", JSON.stringify(res.extensions.server_latency));
+
+    const ppl = res.data;
+
+    // Print results.
+    console.log(`Number of people named "Alice": ${ppl.all.length}`);
+    ppl.all.forEach((person) => console.log(person));
+    return res;
+}
+
+async function main() {
+    const args = minimist(process.argv.slice(2), {
+        string: 'addr',
+        string: 'api-key',
+        boolean: 'drop-all',
+        default: {
+            'addr': 'http://localhost:8080'
+        },
+        alias: { apiKey: 'api-key', dropAll: 'drop-all' }
+    });
+    const dgraphClientStub = newClientStub(args.addr);
+    const dgraphClient = newClient(dgraphClientStub, args.apiKey);
+    if (args.dropAll) {
+        await dropAll(dgraphClient);
+    }
+    await setSchema(dgraphClient);
+    await createData(dgraphClient);
+    await queryData(dgraphClient);
+}
+
+main().then(() => {
+    console.log("\nDONE!");
+}).catch((e) => {
+    console.log("ERROR: ", e);
+});

--- a/examples/latency/index-async-await.js
+++ b/examples/latency/index-async-await.js
@@ -88,6 +88,7 @@ async function createData(dgraphClient) {
 }
 
 // Query for data.
+// This function also logs the client-side and server-side latency for running the query.
 async function queryData(dgraphClient) {
     // Run query.
     const query = `query all($a: string) {

--- a/examples/latency/package.json
+++ b/examples/latency/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "latency",
+  "dependencies": {
+    "dgraph-js-http": "^21.3.0",
+    "minimist": "^1.2.5"
+  }
+}


### PR DESCRIPTION
This is for CLOUD-260.

This adds an example to get the client-side and the server-side latency of a query.

The important bit is the following snippet:

https://github.com/dgraph-io/dgraph-js-http/blob/88ffe9400069489b18526090b35ddf9f55aff125/examples/latency/index-async-await.js#L112-L115

**Client-side latency** is calculated using `console.time` and `console.timeEnd` around a query call to capture the client-side latency.

**Server-side latency** is calculated by Dgraph itself. This example prints it out from the query response `res.extensions.server_latency`.

---

Example command and output:
<pre>
$ node index-async-await.js --addr https://$MY_DGRAPH_CLOUD_ENDPOINT --api-key $MY_API_KEY --drop-all
Created person named "Alice" with uid = 0xbd

All created nodes (map from blank node names to uids):
blank-0 => 0xbd
dg.3043386991.125 => 0xbe
dg.3043386991.126 => 0xbf
dg.3043386991.127 => 0xc0

Query: query all($a: string) { all(func: eq(name, $a)) { uid name age married loc dob friend { name age } school { name } } } Vars: { '$a': 'Alice' }
<strong>Query client latency: 39.371ms</strong>
<strong>Query server latency: {"parsing_ns":299313,"processing_ns":1606551,"encoding_ns":361067,"assign_timestamp_ns":1389885,"total_ns":3770262}</strong>
Number of people named "Alice": 1
{
  uid: '0xbd',
  name: 'Alice',
  age: 26,
  married: true,
  loc: { type: 'Point', coordinates: [ 1.1, 2 ] },
  dob: '1980-02-02T07:00:00Z',
  friend: [ { name: 'Bob', age: 24 }, { name: 'Charlie', age: 29 } ],
  school: [ { name: 'Crown Public School' } ]
}

DONE!
</pre>

The following flags are available in this example:
* `--addr`: The Dgraph address. Can be a Dgraph Cloud endpoint following the instructions: https://github.com/dgraph-io/dgraph-js-http#create-a-client-for-dgraph-cloud-endpoint. Defaults to `http://localhost:8080`.
* `--api-key`: The Dgraph Cloud API Key. Required if the `--addr` is a Dgraph Cloud endpoint.
* `--drop-all`: Call DropAll on Dgraph before loading the data for this example.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js-http/50)
<!-- Reviewable:end -->
