### PR TITLE
docs(login): Use client and add note for cloud.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,13 @@ which will allow the users to login to a specific namespace.
 In order to create a JavaScript client, and make the client login into namespace `123`:
 
 ```js
-const dgraphClientStub = new dgraph.DgraphClientStub("localhost:9080");
-await dgraphClientStub.loginIntoNamespace("groot", "password", 123); // where 123 is the namespaceId 
+await dgraphClient.loginIntoNamespace("groot", "password", 123); // where 123 is the namespaceId 
 ```
 
 In the example above, the client logs into namespace `123` using username `groot` and password `password`.
 Once logged in, the client can perform all the operations allowed to the `groot` user of namespace `123`.
+
+If you're connecting to Dgraph Cloud, call `setCloudApiKey` before calling `loginIntoNamespace`.
 
 ### Create a Client for Dgraph Cloud Endpoint
 


### PR DESCRIPTION
The docs had mentioned to authenticate to Dgraph Cloud using DgraphClient and to login for ACLs with the DgraphClientStub. They don't mix and match very well (the Dgraph Cloud authentication needs to happen first, so the ACL login shouldn't happen in the stub).

It's clearer to have both authentication calls happen after creating the DgraphClient.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js-http/56)
<!-- Reviewable:end -->
