### PR TITLE
Fix problem with install example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ yarn add dgraph-js-http
 or npm:
 
 ```sh
-npm install dgraph-js-http
+npm install dgraph-js-http@21.03.1 --save
 ```
 
 You will also need a Promise polyfill for


### PR DESCRIPTION
For some reason when you run

npm install dgraph-js-http --save

It installs an old version of this lib. We need to fix that, for now we can update the readme.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph-js-http/70)
<!-- Reviewable:end -->
